### PR TITLE
Add method to check wifi access on device

### DIFF
--- a/wlauto/common/android/device.py
+++ b/wlauto/common/android/device.py
@@ -649,6 +649,10 @@ class AndroidDevice(BaseLinuxDevice):  # pylint: disable=W0223
         except KeyError:
             return None
 
+    def is_wifi_connected(self):
+        self.logger.debug('Checking for wi-fi connectivity.')
+        return self.execute('dumpsys wifi| grep curState=ConnectedState')
+
     # Internal methods: do not use outside of the class.
 
     def _update_build_properties(self, filepath, props):


### PR DESCRIPTION
Method to ascertain if wifi connectivity is enabled on the device. Uses
grep and dumpsys. Returns exit code.
