### PR TITLE
Add an internet connection check to all performance workloads

### DIFF
--- a/wlauto/workloads/gmail/__init__.py
+++ b/wlauto/workloads/gmail/__init__.py
@@ -19,6 +19,7 @@ import re
 import time
 
 from wlauto import AndroidUiAutoBenchmark, Parameter
+from wlauto.exceptions import DeviceError
 
 
 class Gmail(AndroidUiAutoBenchmark):
@@ -76,6 +77,9 @@ class Gmail(AndroidUiAutoBenchmark):
 
     def initialize(self, context):
         super(Gmail, self).initialize(context)
+
+        if not self.device.is_wifi_connected():
+            raise DeviceError('Wifi is not connected for device {}'.format(self.device.name))
 
         self.storage_dir = self.device.path.join(self.device.working_directory)
 

--- a/wlauto/workloads/googlephotos/__init__.py
+++ b/wlauto/workloads/googlephotos/__init__.py
@@ -17,6 +17,7 @@ import os
 import re
 
 from wlauto import AndroidUiAutoBenchmark, Parameter
+from wlauto.exceptions import DeviceError
 
 
 class Googlephotos(AndroidUiAutoBenchmark):
@@ -77,6 +78,9 @@ class Googlephotos(AndroidUiAutoBenchmark):
 
     def initialize(self, context):
         super(Googlephotos, self).initialize(context)
+
+        if not self.device.is_wifi_connected():
+            raise DeviceError('Wifi is not connected for device {}'.format(self.device.name))
 
         for entry in os.listdir(self.dependencies_directory):
             wa_file = ''.join([self.file_prefix, entry])

--- a/wlauto/workloads/reader/__init__.py
+++ b/wlauto/workloads/reader/__init__.py
@@ -19,6 +19,7 @@ import re
 import time
 
 from wlauto import AndroidUiAutoBenchmark, Parameter
+from wlauto.exceptions import DeviceError
 
 
 class Reader(AndroidUiAutoBenchmark):
@@ -76,6 +77,12 @@ class Reader(AndroidUiAutoBenchmark):
         self.uiauto_params['email'] = self.email
         self.uiauto_params['password'] = self.password
         self.uiauto_params['dumpsys_enabled'] = self.dumpsys_enabled
+
+    def initialize(self, context):
+        super(Reader, self).initialize(context)
+
+        if not self.device.is_wifi_connected():
+            raise DeviceError('Wifi is not connected for device {}'.format(self.device.name))
 
     def setup(self, context):
         super(Reader, self).setup(context)

--- a/wlauto/workloads/skype/__init__.py
+++ b/wlauto/workloads/skype/__init__.py
@@ -18,6 +18,7 @@ import re
 import time
 
 from wlauto import AndroidUiAutoBenchmark, Parameter
+from wlauto.exceptions import DeviceError
 
 
 SKYPE_ACTION_URIS = {
@@ -93,6 +94,12 @@ class Skype(AndroidUiAutoBenchmark):
         self.uiauto_params['name'] = self.contact_name.replace(' ', '_')
         self.uiauto_params['duration'] = self.duration
         self.uiauto_params['action'] = self.action
+
+    def initialize(self, context):
+        super(Skype, self).initialize(context)
+
+        if not self.device.is_wifi_connected():
+            raise DeviceError('Wifi is not connected for device {}'.format(self.device.name))
 
     def setup(self, context):
         self.logger.info('===== setup() ======')


### PR DESCRIPTION
Throw a DeviceError exception if no wifi connection has been made
during the initialization step of the current workload.
