### PR TITLE
Add version information to workloads

### DIFF
--- a/wlauto/workloads/gmail/__init__.py
+++ b/wlauto/workloads/gmail/__init__.py
@@ -20,6 +20,8 @@ import time
 
 from wlauto import AndroidUiAutoBenchmark, Parameter
 
+__version__ = '0.1.0'
+
 
 class Gmail(AndroidUiAutoBenchmark):
 

--- a/wlauto/workloads/googlephotos/__init__.py
+++ b/wlauto/workloads/googlephotos/__init__.py
@@ -18,6 +18,8 @@ import re
 
 from wlauto import AndroidUiAutoBenchmark, Parameter
 
+__version__ = '0.1.0'
+
 
 class Googlephotos(AndroidUiAutoBenchmark):
 

--- a/wlauto/workloads/reader/__init__.py
+++ b/wlauto/workloads/reader/__init__.py
@@ -20,6 +20,8 @@ import time
 
 from wlauto import AndroidUiAutoBenchmark, Parameter
 
+__version__ = '0.1.0'
+
 
 class Reader(AndroidUiAutoBenchmark):
 

--- a/wlauto/workloads/skype/__init__.py
+++ b/wlauto/workloads/skype/__init__.py
@@ -19,6 +19,7 @@ import time
 
 from wlauto import AndroidUiAutoBenchmark, Parameter
 
+__version__ = '0.1.0'
 
 SKYPE_ACTION_URIS = {
     'call': 'call',


### PR DESCRIPTION
Add a **version** parameter to **init**.py for all workloads. The
version number has three components major.minor.patch.

major: completely new interpretation of the test
       (incompatible with previous test)

minor: breaks compatibility with previous test
       (outputted results, dependencies, etc)

patch: code change with no impact on any dependencies
