### PR TITLE
Grant all permissions starting with 'android.permission'

### DIFF
--- a/wlauto/common/android/workload.py
+++ b/wlauto/common/android/workload.py
@@ -291,8 +291,6 @@ class ApkWorkload(Workload):
         for line in lines:
             if "android.permission." in line:
                 permissions.append(line.split(":")[0].strip())
-            else:
-                break
 
         for permission in permissions:
             # "Normal" Permisions are automatically granted and cannot be changed


### PR DESCRIPTION
Currently, only the only permissions granted are those in first contiguous block of lines that begins with `android.permission`.

This causes problems for apps like Google Slides for example, whose permission list from `dumpsys package` looks as follows:

```
shell@HWNXT:/ $ dumpsys package com.google.android.apps.docs.editors.slides | grep permission                                                                            
  Permission [com.google.android.apps.docs.editors.punch.permission.READ_MY_DATA] (9f86d30):
    perm=Permission{32b4da9 com.google.android.apps.docs.editors.punch.permission.READ_MY_DATA}
  Permission [com.google.android.apps.docs.editors.punch.permission.SYNC_STATUS] (4489acf):
    perm=Permission{d2f2c5c com.google.android.apps.docs.editors.punch.permission.SYNC_STATUS}
  Permission [com.google.android.apps.docs.editors.punch.permission.WRITE_IMAGES] (7c21b65):
    perm=Permission{71ca03a com.google.android.apps.docs.editors.punch.permission.WRITE_IMAGES}
    declared permissions:
      com.google.android.apps.docs.editors.punch.permission.WRITE_IMAGES: prot=signature, INSTALLED
      com.google.android.apps.docs.editors.punch.permission.READ_MY_DATA: prot=signature|privileged, INSTALLED
      com.google.android.apps.docs.editors.punch.permission.SYNC_STATUS: prot=normal, INSTALLED
    requested permissions:
      android.permission.ACCESS_NETWORK_STATE
      android.permission.GET_ACCOUNTS
      android.permission.INTERNET
      android.permission.USE_CREDENTIALS
      android.permission.READ_CONTACTS
      android.permission.WRITE_EXTERNAL_STORAGE
      com.google.android.providers.gsf.permission.READ_GSERVICES
      android.permission.READ_SYNC_SETTINGS
      android.permission.WRITE_SYNC_SETTINGS
      android.permission.SUBSCRIBED_FEEDS_READ
      android.permission.SUBSCRIBED_FEEDS_WRITE
      android.permission.VIBRATE
      com.google.android.apps.docs.editors.punch.permission.WRITE_IMAGES
      com.android.launcher.permission.INSTALL_SHORTCUT
      android.permission.READ_CALENDAR
      android.permission.DOWNLOAD_WITHOUT_NOTIFICATION
      android.permission.ACCESS_WIFI_STATE
      android.permission.BLUETOOTH
      android.permission.CAMERA
      android.permission.MODIFY_AUDIO_SETTINGS
      android.permission.RECORD_AUDIO
      android.permission.MANAGE_ACCOUNTS
      android.permission.AUTHENTICATE_ACCOUNTS
      android.permission.READ_SYNC_STATS
      android.permission.WRITE_SYNC_STATS
      android.permission.WAKE_LOCK
      com.google.android.gm.permission.READ_GMAIL
      com.google.android.googleapps.permission.GOOGLE_AUTH
      com.google.android.googleapps.permission.GOOGLE_AUTH.OTHER_SERVICES
      com.google.android.googleapps.permission.GOOGLE_AUTH.ALL_SERVICES
      com.google.android.googleapps.permission.GOOGLE_AUTH.writely
      com.google.android.googleapps.permission.GOOGLE_AUTH.wise
      com.google.android.apps.docs.editors.punch.permission.READ_MY_DATA
      com.google.android.apps.docs.editors.punch.permission.SYNC_STATUS
      android.permission.READ_USER_DICTIONARY
      android.permission.WRITE_USER_DICTIONARY
      android.permission.READ_EXTERNAL_STORAGE
    install permissions:
      com.google.android.apps.docs.editors.punch.permission.READ_MY_DATA: granted=true
      android.permission.DOWNLOAD_WITHOUT_NOTIFICATION: granted=true
      android.permission.USE_CREDENTIALS: granted=true
      android.permission.MODIFY_AUDIO_SETTINGS: granted=true
      com.google.android.providers.gsf.permission.READ_GSERVICES: granted=true
      android.permission.MANAGE_ACCOUNTS: granted=true
      android.permission.WRITE_SYNC_SETTINGS: granted=true
      android.permission.SUBSCRIBED_FEEDS_READ: granted=true
      android.permission.BLUETOOTH: granted=true
      android.permission.SUBSCRIBED_FEEDS_WRITE: granted=true
      android.permission.AUTHENTICATE_ACCOUNTS: granted=true
      android.permission.INTERNET: granted=true
      android.permission.ACCESS_NETWORK_STATE: granted=true
      com.google.android.apps.docs.editors.punch.permission.SYNC_STATUS: granted=true
      com.google.android.apps.docs.editors.punch.permission.WRITE_IMAGES: granted=true
      android.permission.WRITE_USER_DICTIONARY: granted=true
      android.permission.READ_SYNC_STATS: granted=true
      android.permission.READ_SYNC_SETTINGS: granted=true
      android.permission.VIBRATE: granted=true
      android.permission.READ_USER_DICTIONARY: granted=true
      android.permission.ACCESS_WIFI_STATE: granted=true
      com.android.launcher.permission.INSTALL_SHORTCUT: granted=true
      android.permission.WAKE_LOCK: granted=true
      runtime permissions:
        android.permission.READ_EXTERNAL_STORAGE: granted=true
        android.permission.GET_ACCOUNTS: granted=true
        android.permission.WRITE_EXTERNAL_STORAGE: granted=true
        android.permission.READ_CONTACTS: granted=true
```

Instead of breaking the loop on first non-matching line, this patch just skips such lines.
